### PR TITLE
fixed namecard position and corrected typo

### DIFF
--- a/css/nameMeanings.css
+++ b/css/nameMeanings.css
@@ -31,7 +31,6 @@
 
 .namecards {
   width: 100%;
-  float: left;
   margin: 15px 0;
   border: 5px solid #ccc;
   border-radius: 25px;

--- a/names.html
+++ b/names.html
@@ -57,7 +57,7 @@
           </div>
 
           <!-- Name Generator -->
-          <div id="gen" class="tab-pane fade px-5 py-2 text-center">
+          <div id="gen" class="tab-panel fade px-5 py-2 text-center">
             <div class="">
               <div class="center">
                 <div id="register">


### PR DESCRIPTION
1) The float css property is necessary and causing the footer to shift to the left due to flex box wrapping.
2) There was a typo in one of the css classes 