### PR TITLE
remove inline endscripts, they are included in the global scripts

### DIFF
--- a/halloweenMovies.html
+++ b/halloweenMovies.html
@@ -52,11 +52,7 @@
   <!-- Add page specific link below this line -->
 
   <!-- These two are require for the slider, the dont seem to work in the headFoot.jsinclude -->
-  <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN"
-    crossorigin="anonymous"></script>
-  <!-- Need this version for nameGenerator -->
-  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl"
-    crossorigin="anonymous"></script>
+  <div id="endScripts"></div>
 
   <!-- Loads Nav & Footer - IMPORTANT -->
   <script src="./js/headFoot.js"></script>


### PR DESCRIPTION
The global `headFoot.js` includes jquery and bootstrap, so there is no need to include them twice.
I also accidently removed the `endScripts` tag, which is restored with this.
