### PR TITLE
Fix overlapping book images

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -43,4 +43,4 @@ This is a list showing the GitHub usernames of all who have contributed to this 
 * [@Sanidhya Samadhiya] (https://github.com/sanidhya2000)
 * [@Edward2247](https://github.com/Edward2247)
 * [@rupna](https://github.com/zonex909)
-
+* [@thomlom](https://github.com/thomlom)

--- a/css/books.css
+++ b/css/books.css
@@ -1,33 +1,28 @@
-
 h2 {
   text-align: center;
-  margin:40px 32px;
+  margin: 40px 32px;
 }
 
-.row{
-	margin-top: 50px;
-	}
+.row {
+  margin-top: 50px;
+}
 
 .books {
-	 padding: 40px;
-};
+  padding: 40px;
+}
 
 .card {
   font-family: Helvetica, Arial, sans-serif;
   margin-bottom: 28px;
 }
 
-.card img{
-	height : 400px;
-	width: 233px;
-	
-}
 .card h3 {
   font-size: 15px;
   color: #263238;
 }
 
-.card a, .card p {
+.card a,
+.card p {
   color: #263238;
   font-size: 16px;
 }

--- a/halloweenBooks.html
+++ b/halloweenBooks.html
@@ -1,195 +1,195 @@
-  <!doctype html>
-  <html lang="en">
+<!doctype html>
+<html lang="en">
 
-  <head id="head">
-    <!-- Head information is dynamically loaded -->
-    <!-- If you need to include a different stylesheet do so below -->
+<head id="head">
+  <!-- Head information is dynamically loaded -->
+  <!-- If you need to include a different stylesheet do so below -->
 
-    <script src="./js/cssLoad.js"></script> <!-- Dynamically Imports css -->
-    <link href="./css/books.css" rel="stylesheet">
-    <link rel="stylesheet" type="text/css" href="./css/fog.css" />
-  </head>
+  <script src="./js/cssLoad.js"></script> <!-- Dynamically Imports css -->
+  <link href="./css/books.css" rel="stylesheet">
+  <link rel="stylesheet" type="text/css" href="./css/fog.css" />
+</head>
 
-  <body>
-    <div id="myNav">
-      <!-- NavBar is dynamically loaded -->
-      <!-- If you need to include links check out ./js/headFoot.js -->
-    </div>
-    <div id='fog-roll'>
-       <img src="https://media.giphy.com/media/xEjTM5COAKyNa/giphy-downsized.gif"/>
-    </div>
+<body>
+  <div id="myNav">
+    <!-- NavBar is dynamically loaded -->
+    <!-- If you need to include links check out ./js/headFoot.js -->
+  </div>
+  <div id='fog-roll'>
+    <img src="https://media.giphy.com/media/xEjTM5COAKyNa/giphy-downsized.gif" />
+  </div>
 
-    <main role="main" id="main">
+  <main role="main" id="main">
 
-        <div class="container">
+    <div class="container">
 
-        <h2>Spooky Reads</h2>
+      <h2>Spooky Reads</h2>
 
-        <div class="books">
+      <div class="books">
 
         <div class="row">
 
           <div class="col-sm-6 col-md-3">
             <a href="https://www.goodreads.com/book/show/17061.Coraline">
               <div class="card">
-                  <img class="card-img-top" src="https://images.gr-assets.com/books/1493497435l/17061.jpg" alt="Coraline">
-                  <div class="card-body">
-                    <h3>Coraline</h3>
-                    <p>Neil Gaiman</p>
-                  </div>
+                <img class="card-img-top" src="https://images.gr-assets.com/books/1493497435l/17061.jpg" alt="Coraline">
+                <div class="card-body">
+                  <h3>Coraline</h3>
+                  <p>Neil Gaiman</p>
+                </div>
               </div>
             </a>
           </div>
 
           <div class="col-sm-6 col-md-3">
-              <a href="https://www.goodreads.com/book/show/43763.Interview_with_the_Vampire">
-                <div class="card">
-                    <img class="card-img-top" src="https://images.gr-assets.com/books/1462731030l/9646229.jpg" alt="Interview with the Vampire">
-                    <div class="card-body">
-                      <h3>Interview with the Vampire</h3>
-                      <p>Anne Rice</p>
-                    </div>
+            <a href="https://www.goodreads.com/book/show/43763.Interview_with_the_Vampire">
+              <div class="card">
+                <img class="card-img-top" src="https://images.gr-assets.com/books/1462731030l/9646229.jpg" alt="Interview with the Vampire">
+                <div class="card-body">
+                  <h3>Interview with the Vampire</h3>
+                  <p>Anne Rice</p>
                 </div>
-              </a>
+              </div>
+            </a>
           </div>
 
           <div class="col-sm-6 col-md-3">
-              <a href="https://www.goodreads.com/book/show/21996.The_Devil_in_the_White_City">
-                <div class="card">
-                    <img class="card-img-top" src="https://images.gr-assets.com/books/1388184618l/259028.jpg" alt="The Devil in the White City">
-                    <div class="card-body">
-                      <h3>The Devil in the White City</h3>
-                      <p> Erik Larson</p>
-                    </div>
+            <a href="https://www.goodreads.com/book/show/21996.The_Devil_in_the_White_City">
+              <div class="card">
+                <img class="card-img-top" src="https://images.gr-assets.com/books/1388184618l/259028.jpg" alt="The Devil in the White City">
+                <div class="card-body">
+                  <h3>The Devil in the White City</h3>
+                  <p> Erik Larson</p>
                 </div>
-              </a>
+              </div>
+            </a>
           </div>
 
           <div class="col-sm-6 col-md-3">
-              <a href="https://www.goodreads.com/book/show/11588.The_Shining">
-                <div class="card">
-                    <img class="card-img-top" src="https://images.gr-assets.com/books/1353277730l/11588.jpg" alt="The Shining">
-                    <div class="card-body">
-                      <h3>The Shining</h3>
-                      <p>Stephen King</p>
-                    </div>
+            <a href="https://www.goodreads.com/book/show/11588.The_Shining">
+              <div class="card">
+                <img class="card-img-top" src="https://images.gr-assets.com/books/1353277730l/11588.jpg" alt="The Shining">
+                <div class="card-body">
+                  <h3>The Shining</h3>
+                  <p>Stephen King</p>
                 </div>
-              </a>
+              </div>
+            </a>
           </div>
         </div><!-- /.row -->
 
         <div class="row">
 
-            <div class="col-sm-6 col-md-3">
-              <a href="https://www.goodreads.com/book/show/4602032-dead-until-dark">
-                <div class="card">
-                    <img class="card-img-top" src="https://images.gr-assets.com/books/1266308969l/4602032.jpg" alt="Dead Until Dark">
-                    <div class="card-body">
-                      <h3>Dead Until Dark</h3>
-                      <p>Charlaine Harris</p>
-                    </div>
+          <div class="col-sm-6 col-md-3">
+            <a href="https://www.goodreads.com/book/show/4602032-dead-until-dark">
+              <div class="card">
+                <img class="card-img-top" src="https://images.gr-assets.com/books/1266308969l/4602032.jpg" alt="Dead Until Dark">
+                <div class="card-body">
+                  <h3>Dead Until Dark</h3>
+                  <p>Charlaine Harris</p>
                 </div>
-              </a>
-            </div>
+              </div>
+            </a>
+          </div>
 
-            <div class="col-sm-6 col-md-3">
-                <a href="https://www.goodreads.com/book/show/1325218.Scary_Stories_to_Tell_in_the_Dark">
-                  <div class="card">
-                      <img class="card-img-top" src="https://images.gr-assets.com/books/1440189576l/1325218.jpg" alt="Scary Stories to Tell in the Dark">
-                      <div class="card-body">
-                        <h3>Scary Stories to Tell in the Dark</h3>
-                        <p>Alvin Schwartz</p>
-                      </div>
-                  </div>
-                </a>
-            </div>
+          <div class="col-sm-6 col-md-3">
+            <a href="https://www.goodreads.com/book/show/1325218.Scary_Stories_to_Tell_in_the_Dark">
+              <div class="card">
+                <img class="card-img-top" src="https://images.gr-assets.com/books/1440189576l/1325218.jpg" alt="Scary Stories to Tell in the Dark">
+                <div class="card-body">
+                  <h3>Scary Stories to Tell in the Dark</h3>
+                  <p>Alvin Schwartz</p>
+                </div>
+              </div>
+            </a>
+          </div>
 
-            <div class="col-sm-6 col-md-3">
-                <a href="https://www.goodreads.com/book/show/17245.Dracula">
-                  <div class="card">
-                      <img class="card-img-top" src="https://images.gr-assets.com/books/1394828802l/588495.jpg" alt="Dracula">
-                      <div class="card-body">
-                        <h3>Dracula</h3>
-                        <p>Bram Stoker</p>
-                      </div>
-                  </div>
-                </a>
-            </div>
+          <div class="col-sm-6 col-md-3">
+            <a href="https://www.goodreads.com/book/show/17245.Dracula">
+              <div class="card">
+                <img class="card-img-top" src="https://images.gr-assets.com/books/1394828802l/588495.jpg" alt="Dracula">
+                <div class="card-body">
+                  <h3>Dracula</h3>
+                  <p>Bram Stoker</p>
+                </div>
+              </div>
+            </a>
+          </div>
 
-            <div class="col-sm-6 col-md-3">
-                <a href="https://www.goodreads.com/book/show/89717.The_Haunting_of_Hill_House">
-                  <div class="card">
-                      <img class="card-img-top" src="https://images.gr-assets.com/books/1327871336l/89717.jpg" alt="The Haunting of Hill House">
-                      <div class="card-body">
-                        <h3>The Haunting of Hill House</h3>
-                        <p>Shirley Jackson</p>
-                      </div>
-                  </div>
-                </a>
-            </div>
+          <div class="col-sm-6 col-md-3">
+            <a href="https://www.goodreads.com/book/show/89717.The_Haunting_of_Hill_House">
+              <div class="card">
+                <img class="card-img-top" src="https://images.gr-assets.com/books/1327871336l/89717.jpg" alt="The Haunting of Hill House">
+                <div class="card-body">
+                  <h3>The Haunting of Hill House</h3>
+                  <p>Shirley Jackson</p>
+                </div>
+              </div>
+            </a>
+          </div>
         </div><!-- /.row -->
 
         <div class="row">
-        
-             <div class="col-sm-6 col-md-3">
-                <a href="https://www.goodreads.com/book/show/153025.Heart_Shaped_Box">
-                  <div class="card">
-                      <img class="card-img-top" src="https://images.gr-assets.com/books/1328043955l/153025.jpg" alt="Heart-Shaped Box">
-                      <div class="card-body">
-                        <h3>Heart-Shaped Box</h3>
-                        <p>Joe Hill</p>
-                      </div>
-                  </div>
-                </a>
-            </div>
 
-            <div class="col-sm-6 col-md-3">
-                <a href="https://www.goodreads.com/book/show/23807.The_Silence_of_the_Lambs">
-                  <div class="card">
-                      <img class="card-img-top" src="https://images.gr-assets.com/books/1390426249l/23807.jpg" alt="The Silence of the Lambs">
-                      <div class="card-body">
-                        <h3>The Silence of the Lambs</h3>
-                        <p>Thomas Harris</p>
-                      </div>
-                  </div>
-                </a>
-        </div>
-           <div class="col-sm-6 col-md-3">
-              <a href="https://www.goodreads.com/book/show/12948.The_Turn_of_the_Screw">
-                <div class="card">
-                    <img class="card-img-top" src="https://images.gr-assets.com/books/1443203592l/12948.jpg" alt="The Turn of the Screw">
-                    <div class="card-body">
-                      <h3>The Turn of the Screw</h3>
-                      <p>Henry James</p>
-                    </div>
+          <div class="col-sm-6 col-md-3">
+            <a href="https://www.goodreads.com/book/show/153025.Heart_Shaped_Box">
+              <div class="card">
+                <img class="card-img-top" src="https://images.gr-assets.com/books/1328043955l/153025.jpg" alt="Heart-Shaped Box">
+                <div class="card-body">
+                  <h3>Heart-Shaped Box</h3>
+                  <p>Joe Hill</p>
                 </div>
-              </a>
+              </div>
+            </a>
           </div>
 
-          </div><!-- /.row -->
+          <div class="col-sm-6 col-md-3">
+            <a href="https://www.goodreads.com/book/show/23807.The_Silence_of_the_Lambs">
+              <div class="card">
+                <img class="card-img-top" src="https://images.gr-assets.com/books/1390426249l/23807.jpg" alt="The Silence of the Lambs">
+                <div class="card-body">
+                  <h3>The Silence of the Lambs</h3>
+                  <p>Thomas Harris</p>
+                </div>
+              </div>
+            </a>
+          </div>
+          <div class="col-sm-6 col-md-3">
+            <a href="https://www.goodreads.com/book/show/12948.The_Turn_of_the_Screw">
+              <div class="card">
+                <img class="card-img-top" src="https://images.gr-assets.com/books/1443203592l/12948.jpg" alt="The Turn of the Screw">
+                <div class="card-body">
+                  <h3>The Turn of the Screw</h3>
+                  <p>Henry James</p>
+                </div>
+              </div>
+            </a>
+          </div>
+
+        </div><!-- /.row -->
 
       </div><!-- /.books -->
 
     </div><!-- /.container -->
 
-    </main>
+  </main>
 
-    <div id="myFoot">
-      <!-- Footer is dynamically loaded -->
-      <!-- If you need to include links check out ./js/headFoot.js -->
-    </div>
+  <div id="myFoot">
+    <!-- Footer is dynamically loaded -->
+    <!-- If you need to include links check out ./js/headFoot.js -->
+  </div>
 
-    <div id="endScripts">
-      <!-- Global script files are imported from ./js/headFoot.js -->
-      <!-- Add page specific link below this line -->
-      <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN"
-        crossorigin="anonymous"></script>
-      <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl"
-        crossorigin="anonymous"></script>
-    </div>
+  <div id="endScripts">
+    <!-- Global script files are imported from ./js/headFoot.js -->
+    <!-- Add page specific link below this line -->
+    <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN"
+      crossorigin="anonymous"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl"
+      crossorigin="anonymous"></script>
+  </div>
 
-    <!-- Loads Nav & Footer - IMPORTANT -->
-    <script src="./js/headFoot.js"></script>
-  </body>
+  <!-- Loads Nav & Footer - IMPORTANT -->
+  <script src="./js/headFoot.js"></script>
+</body>
 
-  </html>
+</html>


### PR DESCRIPTION
The book images are given a fixed height and width which make them overlapping each other when we reduce the window size.

That PR fixes that bug by removing unnecessary CSS rules. I did some formatting too to make the CSS code more readable!

Closes #196 